### PR TITLE
Moved code from FeedFragment and fixed API bug

### DIFF
--- a/app/src/main/java/com/example/next_show/adapters/ShowAdapter.java
+++ b/app/src/main/java/com/example/next_show/adapters/ShowAdapter.java
@@ -7,7 +7,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;

--- a/app/src/main/java/com/example/next_show/data/TraktApplication.java
+++ b/app/src/main/java/com/example/next_show/data/TraktApplication.java
@@ -4,12 +4,26 @@ import android.content.Context;
 import android.util.Log;
 
 import com.example.next_show.R;
+import com.example.next_show.fragments.FeedFragment;
+import com.example.next_show.models.Show;
 import com.uwetrottmann.trakt5.TraktV2;
+import com.uwetrottmann.trakt5.entities.TrendingShow;
+import com.uwetrottmann.trakt5.enums.Extended;
 import com.uwetrottmann.trakt5.services.Shows;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 public class TraktApplication {
     // constants
-    public static final String TAG = "TraktApplication";
+    private static final String TAG = "TraktApplication";
+    public static final int PAGES_REQUESTED = 1;
+    public static final int LIMIT = 5;
+
+    // instance var
     private Context context;
 
     // empty constructor
@@ -31,5 +45,30 @@ public class TraktApplication {
         Shows traktShows = trakt.shows();
         Log.i(TAG, "Created new instance for Trakt");
         return traktShows;
+    }
+
+    public static void fetchTrendingShows(Shows showsObj, FeedFragment.ShowCallback showCallback) {
+        Log.i(TAG, "Fetching shows now!");
+        try {
+            // enqueue to do asynchronous call and execute to do it synchronously
+            showsObj.trending(PAGES_REQUESTED, LIMIT, Extended.FULL).enqueue(new Callback<List<TrendingShow>>() {
+                @Override
+                public void onResponse(Call<List<TrendingShow>> call, Response<List<TrendingShow>> response) {
+                    if (response.isSuccessful()) {
+                        showCallback.onSuccess(Show.formatTrendingShows(response.body()));
+                    } else {
+                        showCallback.onFailure(response.code());
+                    }
+                }
+
+                @Override
+                public void onFailure(Call<List<TrendingShow>> call, Throwable t) {
+                    Log.e(TAG, "OnFailure", t);
+                }
+            });
+
+        } catch (Exception e) {
+            Log.e(TAG, "Call error", e);
+        }
     }
 }

--- a/app/src/main/java/com/example/next_show/fragments/ShowDetailFragment.java
+++ b/app/src/main/java/com/example/next_show/fragments/ShowDetailFragment.java
@@ -144,7 +144,7 @@ public class ShowDetailFragment extends Fragment {
                         User currentUser = (User) ParseUser.getCurrentUser();
 
                         if (currShow.getUserLiked().equals(LIKED)) {
-                            currentUser.addToLikedShows(currShow.getId());
+                            currentUser.addToLikedShows(currShow.getSlug());
                         }
 
                         // if no error, let log and user know
@@ -187,7 +187,7 @@ public class ShowDetailFragment extends Fragment {
 
                     // update matching user's saved show list
                     if (r.equals(LIKED)) {
-                        currentUser.addToLikedShows(currShow.getId());
+                        currentUser.addToLikedShows(currShow.getSlug());
                     }
 
                     Log.i(TAG, "Saved new rating!");

--- a/app/src/main/java/com/example/next_show/models/Show.java
+++ b/app/src/main/java/com/example/next_show/models/Show.java
@@ -20,6 +20,7 @@ public class Show extends ParseObject implements Parcelable {
     private String network;
     private String liked;
     private String imageUrl;
+    private String slug;
     private int year_aired;
     private boolean isSaved;
     private List<String> genres;
@@ -32,19 +33,22 @@ public class Show extends ParseObject implements Parcelable {
     public static final String KEY_YEAR_AIRED = "yearAired";
     public static final String KEY_USER = "user";
     public static final String KEY_RATING = "userRating";
+    public static final String KEY_SLUG = "slug";
     public static final String KEY_GENRES = "genres"; // list
     public static final String KEY_IMAGE = "imageUrl"; // TODO: not used yet until API call is fixed
 
     // empty constructor
     public Show() { }
 
-    public Show(String title, String overview, String id, String network, int year_aired, List<String> genres) {
+    public Show(String title, String overview, String id, String network, int year_aired,
+                List<String> genres, String slug) {
         this.title = title;
         this.overview = overview;
         this.id = id;
         this.network = network;
         this.year_aired = year_aired;
         this.genres = genres;
+        this.slug = slug;
         this.isSaved = false; // default is that this new Show object is not saved in Parse
     }
 
@@ -54,11 +58,12 @@ public class Show extends ParseObject implements Parcelable {
         for (TrendingShow trendingShow : response) {
             // grab showID to check if in forbidden shows
             String showID = "" + trendingShow.show.ids.tmdb;
+            String showSlug = "" + trendingShow.show.ids.slug;
 
             if (!isForbiddenShow(showID)) {
                 Show currentShow = new Show(trendingShow.show.title, trendingShow.show.overview,
                         showID, trendingShow.show.network, trendingShow.show.first_aired.getYear(),
-                        trendingShow.show.genres);
+                        trendingShow.show.genres, showSlug);
 
                 updatedShows.add(currentShow);
             }
@@ -72,10 +77,11 @@ public class Show extends ParseObject implements Parcelable {
         for (com.uwetrottmann.trakt5.entities.Show show : repsonseShows) {
             // grab showID to check if in forbidden shows
             String showID = "" + show.ids.tmdb;
+            String showSlug = "" + show.ids.slug;
 
             if (!isForbiddenShow(showID)) {
                 Show currentShow = new Show(show.title, show.overview, showID, show.network,
-                        show.first_aired.getYear(), show.genres);
+                        show.first_aired.getYear(), show.genres, showSlug);
 
                 updatedShows.add(currentShow);
             }
@@ -94,7 +100,7 @@ public class Show extends ParseObject implements Parcelable {
 
             if (!isForbiddenShow(showID)) {
                 Show currentShow = new Show(parseShow.getParseTitle(), parseShow.getParseOverview(), showID,
-                        parseShow.getParseNetwork(), parseShow.getParseYearAired(), parseShow.getParseGenres());
+                        parseShow.getParseNetwork(), parseShow.getParseYearAired(), parseShow.getParseGenres(), parseShow.getParseSlug());
 
                 // for ratings and updating them later
                 currentShow.setObjectID(parseShow.getObjectId());
@@ -143,6 +149,8 @@ public class Show extends ParseObject implements Parcelable {
     public String getUserLiked() { return liked; }
 
     public void setUserLiked(String liked) { this.liked = liked; }
+
+    public String getSlug() { return slug; }
 
     public List<String> getGenres() {
         return genres;
@@ -228,6 +236,14 @@ public class Show extends ParseObject implements Parcelable {
         saveInBackground();
     }
 
+    public String getParseSlug() {
+        return getString(KEY_SLUG);
+    }
+
+    public void setParseSlug(String s) {
+        put(KEY_SLUG, s);
+    }
+
     public String getParseImage() {
         return getString(KEY_IMAGE);
     }
@@ -251,6 +267,7 @@ public class Show extends ParseObject implements Parcelable {
         setParseTVID(id);
         setParseNetwork(network);
         setParseYearAired(year_aired);
+        setParseSlug(slug);
         setParseImage(getImageUrl());
         setParseUser(currUser);
 
@@ -262,4 +279,5 @@ public class Show extends ParseObject implements Parcelable {
         setParseUserLiked(liked);
         setParseGenres(genres);
     }
+
 }

--- a/app/src/main/java/com/example/next_show/models/User.java
+++ b/app/src/main/java/com/example/next_show/models/User.java
@@ -1,14 +1,7 @@
 package com.example.next_show.models;
 
-import android.os.Parcelable;
-
 import com.parse.ParseClassName;
-import com.parse.ParseFile;
 import com.parse.ParseUser;
-
-import org.parceler.Parcel;
-
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -21,8 +14,8 @@ public class User extends ParseUser {
     public static final String KEY_EMAIL = "email";
     public static final String KEY_BIO = "bio";
     public static final String KEY_FAVE_GENRES = "faveGenres";
-    public static final String KEY_FORBIDDEN = "forbiddenShows";
-    public static final String KEY_LIKED_SAVED_SHOWS = "savedShows"; // holds TMDB IDs for LIKED savedShows
+    public static final String KEY_FORBIDDEN = "forbiddenShows"; // holds TVIDs for DELETED SHOWS
+    public static final String KEY_LIKED_SAVED_SHOWS = "savedShows"; // holds SLUGS for LIKED savedShows
 
     // empty constructor
     public User() { }


### PR DESCRIPTION
- Pulled all fetching methods out of FeedFragment into TraktApplication and RecommendationClient
- **FIX**: Trakt changed its API endpoint for grabbing related shows for a particular show ID to using the slug for the endpoint -> had to change the way I saved shows, now using the slug
- When I moved the show fetching to RecommendationClient, my algorithm for grabbing recommendations was messed up. I had to then call the genre matched recommendation call when response fails for the related show call