### PR TITLE
Minor fix from #29 and added saved status on detail page

### DIFF
--- a/app/src/main/java/com/example/next_show/data/ShowFilter.java
+++ b/app/src/main/java/com/example/next_show/data/ShowFilter.java
@@ -156,9 +156,6 @@ public class ShowFilter {
         showGenres.retainAll(compareGenres);
 
         // if genres match
-        if (!showGenres.isEmpty()) {
-            return true;
-        }
-        return false;
+        return !showGenres.isEmpty();
     }
 }

--- a/app/src/main/java/com/example/next_show/fragments/ShowDetailFragment.java
+++ b/app/src/main/java/com/example/next_show/fragments/ShowDetailFragment.java
@@ -1,5 +1,6 @@
 package com.example.next_show.fragments;
 
+import android.graphics.Typeface;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Gravity;
@@ -101,12 +102,12 @@ public class ShowDetailFragment extends Fragment {
 
         // go through show genres and add chips
         List<String> showGenres = currShow.getGenres();
-        int track = 1;
+        int genreChipCount = 1;
         for (String g: showGenres) {
             // only put 3 genres max (formatting constraint)
-            if (track <= MAX_CHIPS){
+            if (genreChipCount <= MAX_CHIPS){
                 addChip(g);
-                track += 1;
+                genreChipCount++;
             } else {
                break;
             }
@@ -115,11 +116,13 @@ public class ShowDetailFragment extends Fragment {
         // check if previous fragment was the SavedFragment -> disable save feature
         if (currShow.isSaved()) {
             btnSaveShow.setVisibility(View.GONE);
+            TextView tvRatingTitle = currView.findViewById(R.id.tvRatingTitle);
+            tvAlreadyRated = currView.findViewById(R.id.tvAlreadyRated);
+            String likedStatus = currShow.getUserLiked();
 
             // check if user already rated it, show if user liked it or not
-            if (currShow.getUserLiked().equals(LIKED) || currShow.getUserLiked().equals(DISLIKED)) {
+            if (likedStatus != null && (likedStatus.equals(LIKED) || likedStatus.equals(DISLIKED))) {
                 String status = (currShow.getUserLiked().equals(LIKED)) ? LIKED : DISLIKED;
-                tvAlreadyRated = currView.findViewById(R.id.tvAlreadyRated);
 
                 // toggle view, remove liked and disliked if rated already
                 btnLiked.setVisibility(View.GONE);
@@ -127,6 +130,12 @@ public class ShowDetailFragment extends Fragment {
 
                 tvAlreadyRated.setVisibility(View.VISIBLE);
                 tvAlreadyRated.setText("You " + status + " this show!");
+            } else {
+                btnLiked.setVisibility(View.GONE);
+                btnDisliked.setVisibility(View.GONE);
+
+                tvRatingTitle.setText("Already saved this show, click Saved tab!");
+                tvRatingTitle.setTypeface(tvRatingTitle.getTypeface(), Typeface.BOLD);
             }
         }
 
@@ -167,6 +176,9 @@ public class ShowDetailFragment extends Fragment {
                         if (currShow.getUserLiked().equals(LIKED)) {
                             currentUser.addToLikedShows(currShow.getSlug());
                         }
+
+                        // add to general list of saved shows
+                        currentUser.addToSavedShows(currShow.getSlug());
 
                         // if no error, let log and user know
                         Log.i(TAG, "Saved post successfully");
@@ -223,6 +235,7 @@ public class ShowDetailFragment extends Fragment {
                     }
 
                     Log.i(TAG, "Saved new rating!");
+                    Toast.makeText(getActivity(), "Updated the rating!", Toast.LENGTH_SHORT).show();
                 }
             }
         });

--- a/app/src/main/java/com/example/next_show/models/Show.java
+++ b/app/src/main/java/com/example/next_show/models/Show.java
@@ -66,6 +66,11 @@ public class Show extends ParseObject implements Parcelable {
                         trendingShow.show.genres, showSlug);
 
                 updatedShows.add(currentShow);
+
+                // for labelling on feedfragment
+                if (isSaved(showSlug)) {
+                    currentShow.setSavedStatus(true);
+                }
             }
         }
         return updatedShows;
@@ -82,6 +87,11 @@ public class Show extends ParseObject implements Parcelable {
             if (!isForbiddenShow(showID)) {
                 Show currentShow = new Show(show.title, show.overview, showID, show.network,
                         show.first_aired.getYear(), show.genres, showSlug);
+
+                // for labelling on feedfragment
+                if (isSaved(showSlug)) {
+                    currentShow.setSavedStatus(true);
+                }
 
                 updatedShows.add(currentShow);
             }
@@ -125,6 +135,18 @@ public class Show extends ParseObject implements Parcelable {
         }
 
         return forbiddenShows.contains(showID);
+    }
+
+    private static boolean isSaved(String slug) {
+        User user = (User) ParseUser.getCurrentUser();
+        List<String> savedShows = user.getAllSavedShows();
+
+        // check if user has saved shows -> trivially true
+        if (savedShows == null || savedShows.isEmpty()) {
+            return true;
+        }
+
+        return savedShows.contains(slug);
     }
 
     // for local instance of Show -> no setter for these, only constructor can set

--- a/app/src/main/java/com/example/next_show/models/User.java
+++ b/app/src/main/java/com/example/next_show/models/User.java
@@ -15,7 +15,8 @@ public class User extends ParseUser {
     public static final String KEY_BIO = "bio";
     public static final String KEY_FAVE_GENRES = "faveGenres";
     public static final String KEY_FORBIDDEN = "forbiddenShows"; // holds TVIDs for DELETED SHOWS
-    public static final String KEY_LIKED_SAVED_SHOWS = "savedShows"; // holds SLUGS for LIKED savedShows
+    public static final String KEY_LIKED_SAVED_SHOWS = "likedShows"; // holds SLUGS for LIKED savedShows
+    public static final String KEY_ALL_SAVED_SHOWS = "savedShows"; // holds SLUGS for all savedShows
 
     // empty constructor
     public User() { }
@@ -68,13 +69,17 @@ public class User extends ParseUser {
         return getList(KEY_LIKED_SAVED_SHOWS);
     }
 
-    public void setLikedShows(List<String> shows){
-        addAllUnique(KEY_LIKED_SAVED_SHOWS, shows);
+    public void addToLikedShows(String s){
+        add(KEY_LIKED_SAVED_SHOWS, s);
         saveInBackground();
     }
 
-    public void addToLikedShows(String s){
-        add(KEY_LIKED_SAVED_SHOWS, s);
+    public List<String> getAllSavedShows() {
+        return getList(KEY_ALL_SAVED_SHOWS);
+    }
+
+    public void addToSavedShows(String s){
+        add(KEY_ALL_SAVED_SHOWS, s);
         saveInBackground();
     }
 


### PR DESCRIPTION
- Added new field to User which creates distinction between savedShows and likedShows
- Lets user know on details page from FeedFragment if in saved shows already so it avoids duplicate saves
- Updates view programmatically to inform user 
- Edited adapter, show model, and details fragment with new User field and processes

Examples of different detail page below...
<img width="380" alt="Screen Shot 2021-08-02 at 4 30 54 PM" src="https://user-images.githubusercontent.com/16446126/127936150-5f242d4c-f9e7-4ab8-8669-572c581c7d91.png">
<img width="383" alt="Screen Shot 2021-08-02 at 4 30 39 PM" src="https://user-images.githubusercontent.com/16446126/127936160-2166bd2d-d19d-4cb9-82f4-4f20c2f4b8cf.png">
